### PR TITLE
added gittu commit <newCommitOnlyCommand>

### DIFF
--- a/bin/gittu.js
+++ b/bin/gittu.js
@@ -429,6 +429,38 @@ program
     }
   });
 
+// QUICK COMMIT command - add all files and commit with required message
+program
+  .command("commit <message>")
+  .description("Add all files and commit with message (required)")
+  .action((message) => {
+    try {
+      if (!isGitRepository()) {
+        console.log(chalk.red("✗ Not a git repository"));
+        console.log(
+          chalk.yellow('💡 Run "gittu init" to initialize a git repository')
+        );
+        return;
+      }
+
+      if (!message || message.trim() === "") {
+        console.log(chalk.red("✗ No commit message provided. Please provide a commit message."));
+        console.log(chalk.yellow('💡 Usage: gittu commit "your commit message"'));
+        return;
+      }
+
+      // Add all files
+      execSync("git add .", { stdio: "inherit" });
+      console.log(chalk.green("✓ Added all files to staging area"));
+
+      execSync(`git commit -m "${message}"`, { stdio: "inherit" });
+      console.log(chalk.green(`✓ Committed: ${message}`));
+    } catch (error) {
+      console.log(chalk.red("✗ Error in commit operation"));
+      console.log(chalk.red(error.message));
+    }
+  });
+
 // Help command
 program
   .command('help')

--- a/package.json
+++ b/package.json
@@ -1,113 +1,118 @@
 {
-    "name": "gittu",
-    "version": "1.0.4",
-    "description": "Fast and simple git operations CLI tool for developers. Streamline your git workflow with powerful commands and intuitive interface.",
-    "main": "bin/gittu.js",
-    "type": "module",
-    "bin": {
-        "gittu": "./bin/gittu.js"
+  "name": "gittu",
+  "version": "1.0.4",
+  "description": "Fast and simple git operations CLI tool for developers. Streamline your git workflow with powerful commands and intuitive interface.",
+  "main": "bin/gittu.js",
+  "type": "module",
+  "bin": {
+    "gittu": "./bin/gittu.js"
+  },
+  "scripts": {
+    "test": "node tests/test.js"
+  },
+  "keywords": [
+    "git",
+    "cli",
+    "fast",
+    "developer",
+    "tools",
+    "git-workflow",
+    "command-line",
+    "productivity",
+    "version-control",
+    "git-helper",
+    "automation",
+    "terminal",
+    "bash",
+    "shell",
+    "git-commands"
+  ],
+  "author": {
+    "name": "ALTAF",
+    "email": "altafhossen.pro@gmail.com",
+    "url": "https://github.com/altafhossen-pro"
+  },
+  "contributors": [
+    {
+      "name": "ALTAF",
+      "email": "altafhossen.pro@gmail.com",
+      "url": "https://github.com/altafhossen-pro"
     },
-    "scripts": {
-        "test": "node tests/test.js"
-    },
-    "keywords": [
-        "git",
-        "cli",
-        "fast",
-        "developer",
-        "tools",
-        "git-workflow",
-        "command-line",
-        "productivity",
-        "version-control",
-        "git-helper",
-        "automation",
-        "terminal",
-        "bash",
-        "shell",
-        "git-commands"
-    ],
-    "author": {
-        "name": "ALTAF",
-        "email": "altafhossen.pro@gmail.com",
-        "url": "https://github.com/altafhossen-pro"
-    },
-    "contributors": [
-        {
-            "name": "ALTAF",
-            "email": "altafhossen.pro@gmail.com",
-            "url": "https://github.com/altafhossen-pro"
-        }
-    ],
-    "license": "MIT",
-    "homepage": "https://github.com/altafhossen-pro/gittu#readme",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/altafhossen-pro/gittu.git"
-    },
-    "bugs": {
-        "url": "https://github.com/altafhossen-pro/gittu/issues",
-        "email": "altafhossen-pro@gmail.com"
-    },
-    "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/altafhossen-pro"
-    },
-    "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
-    },
-    "preferGlobal": true,
-    "dependencies": {
-        "chalk": "^5.4.1",
-        "child_process": "^1.0.2",
-        "commander": "^9.0.0"
-    },
-    "devDependencies": {},
-    "peerDependencies": {
-        "git": ">=2.0.0"
-    },
-    "bundledDependencies": [],
-    "optionalDependencies": {},
-    "files": [
-        "bin/",
-        "lib/",
-        "README.md",
-        "LICENSE",
-        "CHANGELOG.md"
-    ],
-    "directories": {
-        "bin": "./bin",
-        "lib": "./lib",
-        "test": "./tests",
-        "doc": "./docs"
-    },
-    "config": {
-        "gittu": {
-            "defaultBranch": "master",
-            "autoUpdate": true,
-            "colorOutput": true
-        }
-    },
-    "husky": {
-        "hooks": {
-            "pre-commit": "lint-staged",
-            "pre-push": "npm run test"
-        }
-    },
-    "lint-staged": {
-        "*.js": [
-            "eslint --fix",
-            "prettier --write",
-            "git add"
-        ]
-    },
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "private": false,
-    "workspaces": [
-        "packages/*"
+    {
+      "name": "AMIN",
+      "email": "mdalaminmollah000@gmail.com",
+      "url": "https://github.com/maamspy"
+    }
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/altafhossen-pro/gittu#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/altafhossen-pro/gittu.git"
+  },
+  "bugs": {
+    "url": "https://github.com/altafhossen-pro/gittu/issues",
+    "email": "altafhossen-pro@gmail.com"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/altafhossen-pro"
+  },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=6.0.0"
+  },
+  "preferGlobal": true,
+  "dependencies": {
+    "chalk": "^5.4.1",
+    "child_process": "^1.0.2",
+    "commander": "^9.0.0"
+  },
+  "devDependencies": {},
+  "peerDependencies": {
+    "git": ">=2.0.0"
+  },
+  "bundledDependencies": [],
+  "optionalDependencies": {},
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "directories": {
+    "bin": "./bin",
+    "lib": "./lib",
+    "test": "./tests",
+    "doc": "./docs"
+  },
+  "config": {
+    "gittu": {
+      "defaultBranch": "master",
+      "autoUpdate": true,
+      "colorOutput": true
+    }
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged",
+      "pre-push": "npm run test"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "prettier --write",
+      "git add"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "private": false,
+  "workspaces": [
+    "packages/*"
+  ]
 }


### PR DESCRIPTION
# Add `commit` Command

This pull request adds a new `commit <message>` command to the CLI.

## What It Does
- Stages all files using `git add .`
- Commits with the provided message using `git commit -m "<message>"`

## How to Use
```bash
gittu commit "Your commit message"
```

## Features
- Checks if you're in a Git repository
- Requires a non-empty commit message
- Shows helpful messages for success and errors

## Why
This makes it easier to quickly stage and commit changes with one command.