### PR TITLE
added gittu save <newCommitOnlyCommand>

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ gittu quick "Initial commit"
 ### Power Commands
 | Command | Description |
 |---------|-------------|
+| `gittu save [message]` | Add + commit (no push) in one command |
 | `gittu quick [message]` | Add + commit + push in one command |
 | `gittu help` | Show detailed help and examples |
 

--- a/bin/gittu.js
+++ b/bin/gittu.js
@@ -429,6 +429,39 @@ program
     }
   });
 
+
+  // SAVE command - add + commit only (no push)
+program
+.command('save [message]')
+.description('Stage and commit changes without pushing')
+.action((message) => {
+  try {
+    if (!isGitRepository()) {
+      console.log(chalk.red('✗ Not a git repository'));
+      console.log(chalk.yellow('💡 Run "gittu init" to initialize a git repository'));
+      return;
+    }
+
+    console.log(chalk.blue('💾 Saving changes (add + commit)...'));
+
+    // Set default message if not provided
+    const commitMessage = message || `Save update - ${new Date().toISOString().split('T')[0]}`;
+
+    // Add all files
+    execSync('git add .', { stdio: 'pipe' });
+    console.log(chalk.green('✓ Added all files'));
+
+    // Commit with message
+    execSync(`git commit -m "${commitMessage}"`, { stdio: 'pipe' });
+    console.log(chalk.green(`✓ Committed: ${commitMessage}`));
+
+    console.log(chalk.blue('✅ Save operation completed (no push)'));
+  } catch (error) {
+    console.log(chalk.red('✗ Error in save operation'));
+    console.log(chalk.red(error.message));
+  }
+});
+
 // Help command
 program
   .command('help')

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
             "name": "ALTAF",
             "email": "altafhossen.pro@gmail.com",
             "url": "https://github.com/altafhossen-pro"
+        },{
+            "name": "AMIN",
+            "email": "mdalaminmollah000@gmail.com",
+            "url": "https://github.com/maamspy"
         }
     ],
     "license": "MIT",


### PR DESCRIPTION
This pull request adds a new command to the `gittu` CLI tool:

```
gittu save [message]
```

The `save` command stages all current changes and creates a commit with the provided message. Unlike the existing `quick` command, it does **not** push to any remote. This is useful for creating local commits quickly without syncing to a remote repository.

## Details

- **Command**: `save [message]`
- **Behavior**:
  - Runs `git add .`
  - Commits with the provided message (or a default message if none is given)
  - Does **not** perform a push
- **Default commit message**: `Save update - YYYY-MM-DD`

## Use Case

Developers often want to create local commits during work-in-progress cycles without pushing to a remote. This command simplifies that workflow.

## Example

```bash
gittu save "Refactor login logic"
```

## Notes

- Uses existing error handling and messaging patterns
- Skips push logic entirely